### PR TITLE
I2C bus reset with info to user

### DIFF
--- a/cores/esp8266/core_esp8266_si2c.c
+++ b/cores/esp8266/core_esp8266_si2c.c
@@ -197,3 +197,18 @@ unsigned char twi_readFrom(unsigned char address, unsigned char* buf, unsigned i
   }
   return 0;
 }
+
+uint8_t twi_status(){           
+    if (SCL_READ()==0)     return I2C_SCL_HELD_LOW;       		//SCL held low by another device, no procedure available to recover
+    int clockCount = 20;                   
+
+    while (SDA_READ()==0 && clockCount>0){                      //if SDA low, read the bits slaves have to sent to a max
+        twi_read_bit();                    
+        if (SCL_READ()==0) return I2C_SCL_HELD_LOW_AFTER_READ;  //I2C bus error. SCL held low beyond slave clock stretch time
+    }
+
+    if (SDA_READ()==0)     return I2C_SDA_HELD_LOW;       		//I2C bus error. SDA line held low by slave/another_master after n bits.
+
+    if(!twi_write_start()) return I2C_SDA_HELD_LOW_AFTER_INIT;  //line busy. SDA again held low by another device. 2nd master?
+    else                   return I2C_OK;       				//all ok 
+}

--- a/cores/esp8266/twi.h
+++ b/cores/esp8266/twi.h
@@ -26,12 +26,19 @@
 extern "C" {
 #endif
 
+#define I2C_OK                      0
+#define I2C_SCL_HELD_LOW            1
+#define I2C_SCL_HELD_LOW_AFTER_READ 2
+#define I2C_SDA_HELD_LOW            3
+#define I2C_SDA_HELD_LOW_AFTER_INIT 4
+
 void twi_init(unsigned char sda, unsigned char scl);
 void twi_stop(void);
 void twi_setClock(unsigned int freq);
 void twi_setClockStretchLimit(uint32_t limit);
 uint8_t twi_writeTo(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
 uint8_t twi_readFrom(unsigned char address, unsigned char * buf, unsigned int len, unsigned char sendStop);
+uint8_t twi_status();
 
 #ifdef __cplusplus
 }

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -77,6 +77,10 @@ void TwoWire::begin(uint8_t address){
   begin();
 }
 
+uint8_t TwoWire::status(){
+	return twi_status();
+}
+
 void TwoWire::begin(int address){
   begin((uint8_t)address);
 }

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -62,6 +62,7 @@ class TwoWire : public Stream
     uint8_t endTransmission(void);
     uint8_t endTransmission(uint8_t);
     size_t requestFrom(uint8_t address, size_t size, bool sendStop);
+	uint8_t status();
 
     uint8_t requestFrom(uint8_t, uint8_t);
     uint8_t requestFrom(uint8_t, uint8_t, uint8_t);


### PR DESCRIPTION
I2C slave might stil have something to send when ESP826 starts I2C, thus
keeping the bus stuck.
Happens e.g. when power failure/reset during transmission.
Thanks to work of drmpf there is a solution.
Implemented as separate method so as not to interfere with existing.
Usage:

Wire.begin();
if (Wire.status() != I2C_OK) Serial.writeln("Something wrong with I2C
bus that cannot be recovered. Perform power cycle or search for other
masters on bus.";
